### PR TITLE
Added JaResource.validation_errors type

### DIFF
--- a/lib/ja_resource.ex
+++ b/lib/ja_resource.ex
@@ -4,6 +4,7 @@ defmodule JaResource do
   @type params :: map()
   @type attributes :: map()
   @type id :: String.t
+  @type validation_errors :: {:error, Ecto.Changeset.t}
 
   @moduledoc """
   When used, includes all restful actions behaviours. Also a plug.


### PR DESCRIPTION
Closes #47

`JaResource.Create` uses a `JaResource.validation_errors` type, although this type is nowhere to be found. This PR adds a definition for it as `{:error, Ecto.Changeset.t}` .