### PR TITLE
Fix common x does not exist and is being expanded to x() warnings

### DIFF
--- a/lib/ja_resource/create.ex
+++ b/lib/ja_resource/create.ex
@@ -73,11 +73,11 @@ defmodule JaResource.Create do
 
   @doc false
   def insert(%Ecto.Changeset{} = changeset, controller) do
-    controller.repo.insert(changeset)
+    controller.repo().insert(changeset)
   end
   if Code.ensure_loaded?(Ecto.Multi) do
     def insert(%Ecto.Multi{} = multi, controller) do
-      controller.repo.transaction(multi)
+      controller.repo().transaction(multi)
     end
   end
   def insert(other, _controller), do: other

--- a/lib/ja_resource/delete.ex
+++ b/lib/ja_resource/delete.ex
@@ -47,7 +47,7 @@ defmodule JaResource.Delete do
       use JaResource.Record
       @behaviour JaResource.Delete
       def handle_delete(conn, nil), do: nil
-      def handle_delete(conn, model), do: __MODULE__.repo.delete(model)
+      def handle_delete(conn, model), do: __MODULE__.repo().delete(model)
 
       defoverridable [handle_delete: 2]
     end

--- a/lib/ja_resource/record.ex
+++ b/lib/ja_resource/record.ex
@@ -36,7 +36,7 @@ defmodule JaResource.Record do
       def record(conn, id) do
         conn
         |> records
-        |> repo.get(id)
+        |> repo().get(id)
       end
 
       defoverridable [record: 2]

--- a/lib/ja_resource/repo.ex
+++ b/lib/ja_resource/repo.ex
@@ -18,7 +18,7 @@ defmodule JaResource.Repo do
   defmacro __using__(_opts) do
     quote do
       @behaviour JaResource.Repo
-      unquote(default_repo)
+      unquote(default_repo())
     end
   end
 

--- a/lib/ja_resource/update.ex
+++ b/lib/ja_resource/update.ex
@@ -80,11 +80,11 @@ defmodule JaResource.Update do
 
   @doc false
   def update(%Ecto.Changeset{} = changeset, controller) do
-    controller.repo.update(changeset)
+    controller.repo().update(changeset)
   end
   if Code.ensure_loaded?(Ecto.Multi) do
     def update(%Ecto.Multi{} = multi, controller) do
-      controller.repo.transaction(multi)
+      controller.repo().transaction(multi)
     end
   end
   def update(other, _controller), do: other

--- a/mix.exs
+++ b/mix.exs
@@ -8,9 +8,9 @@ defmodule JaResource.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      source_url: "https://github.com/AgilionApps/ja_resource",
-     package: package,
-     description: description,
-     deps: deps]
+     package: package(),
+     description: description(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
This fixes the most commonly encountered `x does not exist and is being expanded to x()` warnings.

I'm not sure if it resolves all instances of this issue, but it's really difficult to look for these.

Either way, progress on #49 