### PR TITLE
Overridable create & update callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,3 +340,55 @@ end
 The record argument (`post` in the above example) is the record found by the
 `record/2` callback. If `record/2` can not find a record it will be nil.
 
+### Custom responses
+
+It is possible to override the default responses for create and update actions
+in both the success and invalid cases.
+
+#### Create
+
+Customizing the create response can be done with the `render_create/2` and
+`handle_invalid_create/2` functions. For example:
+
+```elixir
+defmodule MyApp.V1.PostController do
+  use MyApp.Web, :controller
+  use JaResource
+
+  def render_create(conn, model) do
+    conn
+    |> Plug.Conn.put_status(:ok)
+    |> Phoenix.Controller.render(:show, data: model)
+  end
+
+  def handle_invalid_create(conn, errors),
+    conn
+    |> Plug.Conn.put_status(401)
+    |> Phoenix.Controller.render(:errors, data: errors)
+  end
+end
+```
+
+### Update
+
+Customizing the update response can be done with the `render_update/2` and
+`handle_invalid_update/2` functions. For example:
+
+```elixir
+defmodule MyApp.V1.PostController do
+  use MyApp.Web, :controller
+  use JaResource
+
+  def render_update(conn, model) do
+    conn
+    |> Plug.Conn.put_status(:created)
+    |> Phoenix.Controller.render(:show, data: model)
+  end
+
+  def handle_invalid_update(conn, errors) do
+    conn
+    |> Plug.Conn.put_status(401)
+    |> Phoenix.Controller.render(:errors, data: errors)
+  end
+end
+```

--- a/test/ja_resource/update_test.exs
+++ b/test/ja_resource/update_test.exs
@@ -24,6 +24,17 @@ defmodule JaResource.UpdateTest do
     end
   end
 
+  defmodule CustomResponseController do
+    use Phoenix.Controller
+    use JaResource.Update
+    def repo, do: JaResourceTest.Repo
+    def model, do: JaResourceTest.Post
+    def handle_invalid_update(conn, errors),
+      do: put_status(conn, 401) |> Phoenix.Controller.render(:errors, data: errors)
+    def render_update(conn, model),
+      do: put_status(conn, :created) |> Phoenix.Controller.render(:show, data: model)
+  end
+
   test "default implementation renders 404 if record not found" do
     conn = prep_conn(:put, "/posts/404", ja_attrs(404, %{"title" => "valid"}))
     response = Update.call(DefaultController, conn)
@@ -62,6 +73,20 @@ defmodule JaResource.UpdateTest do
     conn = prep_conn(:put, "/posts/#{post.id}", ja_attrs(post.id, %{"title" => "invalid"}))
     response = Update.call(CustomController, conn)
     assert response.status == 422
+  end
+
+  test "custom implementation renders 401 if invalid" do
+    {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 422})
+    conn = prep_conn(:put, "/posts/#{post.id}", ja_attrs(post.id, %{"title" => "invalid"}))
+    response = Update.call(CustomResponseController, conn)
+    assert response.status == 401
+  end
+
+  test "custom implementation renders 201 if valid" do
+    {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.Post{id: 200})
+    conn = prep_conn(:put, "/posts/#{post.id}", ja_attrs(post.id, %{"title" => "valid"}))
+    response = Update.call(CustomResponseController, conn)
+    assert response.status == 201
   end
 
   def prep_conn(method, path, params \\ %{}) do


### PR DESCRIPTION
Adds new callbacks on create and update to allow for overriding of responses to errors and success. Default behaviour works as before. As discussed in #30.