### PR TITLE
Test multi usage on create and handle errors

### DIFF
--- a/lib/ja_resource/create.ex
+++ b/lib/ja_resource/create.ex
@@ -112,6 +112,7 @@ defmodule JaResource.Create do
   @doc false
   def respond(%Plug.Conn{} = conn, _old_conn, _), do: conn
   def respond({:error, errors}, conn, controller), do: controller.handle_invalid_create(conn, errors)
+  def respond({:error, _name, errors, _changes}, conn, controller), do: controller.handle_invalid_create(conn, errors)
   def respond({:ok, model}, conn, controller), do: controller.render_create(conn, model)
   def respond(model, conn, controller), do: controller.render_create(conn, model)
 end

--- a/lib/ja_resource/update.ex
+++ b/lib/ja_resource/update.ex
@@ -120,6 +120,7 @@ defmodule JaResource.Update do
   def respond(%Plug.Conn{} = conn, _oldconn, _), do: conn
   def respond(nil, conn, _), do: send_resp(conn, :not_found, "")
   def respond({:error, errors}, conn, controller), do: controller.handle_invalid_update(conn, errors)
+  def respond({:error, _name, errors, _changes}, conn, controller), do: controller.handle_invalid_update(conn, errors)
   def respond({:ok, model}, conn, controller), do: controller.render_update(conn, model)
   def respond(model, conn, controller), do: controller.render_update(conn, model)
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -88,6 +88,20 @@ defmodule JaResourceTest.Repo do
       MapSet.delete(state, old)
     end
   end
+
+  def transaction(%Ecto.Multi{operations: [{schema, {:changeset, %Ecto.Changeset{valid?: false} = changeset, _}}]}) do
+    {:error, schema, changeset, %{}}
+  end
+
+  def transaction(%Ecto.Multi{operations: [{schema, {:changeset, %Ecto.Changeset{valid?: true, action: :insert} = changeset, _}}]}) do
+    {:ok, inserted} = insert(changeset.data)
+    {:ok, %{schema => inserted}}
+  end
+
+  def transaction(%Ecto.Multi{operations: [{schema, {:changeset, %Ecto.Changeset{valid?: true, action: :update} = changeset, _}}]}) do
+    {:ok, updated} = update(changeset)
+    {:ok, %{schema => updated}}
+  end
 end
 
 # We don't actually need to use Ecto.Schema, just implement it's api.


### PR DESCRIPTION
Adds a valid multi test on create action. Also adds support for passing an error
through from a multi. This was previously causing an error because no
matching respond function was available.

If this looks ok I can go ahead and add similar tests and error handling to the update action too.