### PR TITLE
Tiny typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ defmodule MyApp.ArticleController do
   end
 
   def sort(_conn, query, "published", direction) do
-    order_by(query, [{direction, :inserted_at}])
+    order_by(query, [{^direction, :inserted_at}])
   end
 end
 ```


### PR DESCRIPTION
This variable needs to be explicitly interpolated as it's in a query.