### PR TITLE
fixes #69

### DIFF
--- a/lib/ja_resource/delete.ex
+++ b/lib/ja_resource/delete.ex
@@ -46,7 +46,11 @@ defmodule JaResource.Delete do
       use JaResource.Record
       @behaviour JaResource.Delete
       def handle_delete(conn, nil), do: nil
-      def handle_delete(conn, model), do: __MODULE__.repo().delete(model)
+      def handle_delete(conn, model) do
+        model
+        |> __MODULE__.model.changeset(%{})
+        |> __MODULE__.repo().delete
+      end
 
       defoverridable [handle_delete: 2]
     end
@@ -68,6 +72,7 @@ defmodule JaResource.Delete do
   def respond(%Plug.Conn{} = conn, _old_conn), do: conn
   def respond({:ok, _model}, conn), do: deleted(conn)
   def respond({:errors, errors}, conn), do: invalid(conn, errors)
+  def respond({:error, errors}, conn), do: invalid(conn, errors)
   def respond(_model, conn), do: deleted(conn)
 
   defp not_found(conn) do

--- a/test/ja_resource/delete_test.exs
+++ b/test/ja_resource/delete_test.exs
@@ -10,6 +10,13 @@ defmodule JaResource.DeleteTest do
     def model, do: JaResourceTest.Post
   end
 
+  defmodule FailingOnDeleteController do
+    use Phoenix.Controller
+    use JaResource.Delete
+    def repo, do: JaResourceTest.Repo
+    def model, do: JaResourceTest.FailingOnDeletePost
+  end
+
   defmodule CustomController do
     use Phoenix.Controller
     use JaResource.Delete
@@ -34,6 +41,13 @@ defmodule JaResource.DeleteTest do
     conn = prep_conn(:delete, "/posts/#{post.id}", %{"id" => post.id})
     response = Delete.call(DefaultController, conn)
     assert response.status == 204
+  end
+
+  test "failing on delete returns 422 if model fails on changeset validation" do
+    {:ok, post} = JaResourceTest.Repo.insert(%JaResourceTest.FailingOnDeletePost{id: 422})
+    conn = prep_conn(:delete, "/posts/#{post.id}", %{"id" => post.id})
+    response = Delete.call(FailingOnDeleteController, conn)
+    assert response.status == 422
   end
 
   test "custom implementation retuns 401 if not admin" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -41,10 +41,10 @@ defmodule JaResourceTest.Repo do
     end
   end
 
-  def get(query, id) do
+  def get(_query, id) do
     Agent.get __MODULE__, fn(state) ->
       Enum.find state, fn(record) ->
-        record.__struct__ == query && record.id == id
+        record.id == id
       end
     end
   end
@@ -78,6 +78,10 @@ defmodule JaResourceTest.Repo do
       |> MapSet.delete(old)
       |> MapSet.put(Map.merge(old, new))
     end
+  end
+
+  def delete(%Ecto.Changeset{valid?: false} = changeset) do
+    {:error, changeset}
   end
 
   def delete(to_delete) do
@@ -118,6 +122,19 @@ defmodule JaResourceTest.Post do
       "invalid" -> %Ecto.Changeset{data: model, valid?: false, errors: [title: "is invalid"]}
       _         -> %Ecto.Changeset{data: model, valid?: true}
     end
+  end
+end
+
+defmodule JaResourceTest.FailingOnDeletePost do
+  defstruct [id: 0, title: "title", body: "body", slug: "slug"]
+
+  def changeset(_model, params) do
+    model = %__MODULE__{
+      title: params["title"],
+      body:  params["body"],
+      slug:  params["slug"]
+    }
+    %Ecto.Changeset{data: model, valid?: false, errors: [title: "something went wrong"]}
   end
 end
 


### PR DESCRIPTION
Hi, I tried to fix this issue.

Now, the `handle_delete` is able to check for `changeset` validation errors and in case of errors it will respond with an `unprocessable entity` (http status 422).